### PR TITLE
Added test specifically to validate JRD.

### DIFF
--- a/tests/webfinger/server/4__2_returns_valid_jrd.py
+++ b/tests/webfinger/server/4__2_returns_valid_jrd.py
@@ -1,0 +1,30 @@
+from hamcrest import any_of, assert_that, equal_to, is_not, starts_with
+
+from feditest import test
+from feditest.protocols.web.traffic import HttpResponse
+from feditest.protocols.webfinger import WebFingerClient, WebFingerServer
+
+from feditest.protocols.webfinger.traffic import ClaimedJrd
+
+@test
+def returns_valid_jrd(
+        client: WebFingerClient,
+        server: WebFingerServer
+) -> None:
+    test_id = server.obtain_account_identifier()
+
+    webfinger_uri = client.construct_webfinger_uri_for(test_id)
+
+    # TODO Not sure if this could use perform_webfinger_query ???
+    response : HttpResponse = client.http_get(webfinger_uri).response
+    assert_that(response.http_status, equal_to(200))
+    assert_that(response.response_headers.get('content-type'),
+        any_of(
+                equal_to('application/jrd+json'),
+                starts_with('application/jrd+json;')))
+
+    jrd = ClaimedJrd(response.payload)
+    try:
+        jrd.validate()
+    except ClaimedJrd.JrdError as ex:
+        raise AssertionError(*ex.args[1:])


### PR DESCRIPTION
There was a similar test, but it was primarily focused on http vs https checking. Having this test allows us to not do strict JRD checking in the client node implementation and let the test determine if there is an issue.