### PR TITLE
Remove missing 'follow_redirects' parameter

### DIFF
--- a/tests/webfinger/server/4__3_only_returns_jrd_in_response_to_https_requests.py
+++ b/tests/webfinger/server/4__3_only_returns_jrd_in_response_to_https_requests.py
@@ -24,7 +24,7 @@ def only_returns_jrd_in_response_to_https(
                 equal_to('application/jrd+json'),
                 starts_with('application/jrd+json;')))
 
-    http_response : HttpResponse = client.http_get(http_webfinger_uri, follow_redirects=False).response
+    http_response : HttpResponse = client.http_get(http_webfinger_uri).response
     assert_that(http_response.http_status, is_not(equal_to(200)))
     assert_that(http_response.response_headers.get('content-type'),
         is_not(any_of(


### PR DESCRIPTION
Simplest possible fix for the following failure which I saw:
```
2024-05-11T13:35:37Z [ERROR] feditest: FAILED test (other reason): webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::only_returns_jrd_in_response_to_https: WebClient.http_get() got an unexpected keyword argument 'follow_redirects' Traceback (most recent call last):

  File "/home/mike/devel/fediverse/feditest/feditest/venv/lib/python3.11/site-packages/feditest/__init__.py", line 91, in run
    self.test_function(**args)

  File "/home/mike/devel/fediverse/feditest/feditest-tests-fediverse/tests/webfinger/server/4__3_only_returns_jrd_in_response_to_https_requests.py", line 27, in only_returns_jrd_in_response_to_https
    http_response : HttpResponse = client.http_get(http_webfinger_uri, follow_redirects=False).response
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

TypeError: WebClient.http_get() got an unexpected keyword argument 'follow_redirects'
```