### PR TITLE
Reviewed test output; improvements

### DIFF
--- a/examples/session-templates/webfinger-server-all.json
+++ b/examples/session-templates/webfinger-server-all.json
@@ -1,8 +1,8 @@
 {
     "constellation": {
         "roles": {
-            "server": null,
-            "client": null
+            "client": null,
+            "server": null
         },
         "name": null
     },
@@ -10,104 +10,136 @@
         {
             "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
             "rolemapping": {
-                "server": "server",
-                "client": "client"
+                "client": "client",
+                "server": "server"
             },
             "skip": null
         },
         {
             "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
             "rolemapping": {
-                "server": "server",
-                "client": "client"
+                "client": "client",
+                "server": "server"
             },
             "skip": null
         },
         {
-            "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri",
+            "name": "webfinger.server.4_2__2_perform_query::normal_query",
             "rolemapping": {
-                "server": "server",
-                "client": "client"
+                "client": "client",
+                "server": "server"
             },
             "skip": null
         },
         {
-            "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals",
+            "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
             "rolemapping": {
-                "server": "server",
-                "client": "client"
+                "client": "client",
+                "server": "server"
             },
             "skip": null
         },
         {
-            "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri",
+            "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
             "rolemapping": {
-                "server": "server",
-                "client": "client"
+                "client": "client",
+                "server": "server"
+            },
+            "skip": null
+        },
+        {
+            "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
+            "rolemapping": {
+                "client": "client",
+                "server": "server"
+            },
+            "skip": null
+        },
+        {
+            "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
+            "rolemapping": {
+                "client": "client",
+                "server": "server"
+            },
+            "skip": null
+        },
+        {
+            "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
+            "rolemapping": {
+                "client": "client",
+                "server": "server"
+            },
+            "skip": null
+        },
+        {
+            "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
+            "rolemapping": {
+                "client": "client",
+                "server": "server"
             },
             "skip": null
         },
         {
             "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
             "rolemapping": {
-                "server": "server",
-                "client": "client"
+                "client": "client",
+                "server": "server"
+            },
+            "skip": null
+        },
+        {
+            "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
+            "rolemapping": {
+                "client": "client",
+                "server": "server"
             },
             "skip": null
         },
         {
             "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
             "rolemapping": {
-                "server": "server",
-                "client": "client"
+                "client": "client",
+                "server": "server"
             },
             "skip": null
         },
         {
             "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
             "rolemapping": {
-                "server": "server",
-                "client": "client"
+                "client": "client",
+                "server": "server"
             },
             "skip": null
         },
         {
             "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
             "rolemapping": {
-                "server": "server",
-                "client": "client"
+                "client": "client",
+                "server": "server"
             },
             "skip": null
         },
         {
             "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
             "rolemapping": {
-                "server": "server",
-                "client": "client"
+                "client": "client",
+                "server": "server"
             },
             "skip": null
         },
         {
             "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
             "rolemapping": {
-                "server": "server",
-                "client": "client"
-            },
-            "skip": null
-        },
-        {
-            "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::returns_jrd_in_response_to_https",
-            "rolemapping": {
-                "server": "server",
-                "client": "client"
+                "client": "client",
+                "server": "server"
             },
             "skip": null
         },
         {
             "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
             "rolemapping": {
-                "server": "server",
-                "client": "client"
+                "client": "client",
+                "server": "server"
             },
             "skip": null
         }

--- a/examples/testplans/webfinger-server-gargron-mastodon-social-saas-imp.json
+++ b/examples/testplans/webfinger-server-gargron-mastodon-social-saas-imp.json
@@ -23,104 +23,136 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri",
+                    "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
-                    },
-                    "skip": null
-                },
-                {
-                    "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::returns_jrd_in_response_to_https",
-                    "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }

--- a/examples/testplans/webfinger-server-ubos-mastodon-imp.json
+++ b/examples/testplans/webfinger-server-ubos-mastodon-imp.json
@@ -24,104 +24,136 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri",
+                    "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
-                    },
-                    "skip": null
-                },
-                {
-                    "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::returns_jrd_in_response_to_https",
-                    "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }

--- a/examples/testplans/webfinger-server-ubos-mastodon-wordpress-imp.json
+++ b/examples/testplans/webfinger-server-ubos-mastodon-wordpress-imp.json
@@ -24,104 +24,136 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri",
+                    "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
-                    },
-                    "skip": null
-                },
-                {
-                    "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::returns_jrd_in_response_to_https",
-                    "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
@@ -151,104 +183,136 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri",
+                    "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
-                    },
-                    "skip": null
-                },
-                {
-                    "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::returns_jrd_in_response_to_https",
-                    "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }

--- a/examples/testplans/webfinger-server-ubos-wordpress-imp.json
+++ b/examples/testplans/webfinger-server-ubos-wordpress-imp.json
@@ -23,104 +23,136 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri",
+                    "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
-                    },
-                    "skip": null
-                },
-                {
-                    "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::returns_jrd_in_response_to_https",
-                    "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }

--- a/production/constellations/imp-vs-drupal-acct_swental@realize.be.json
+++ b/production/constellations/imp-vs-drupal-acct_swental@realize.be.json
@@ -9,7 +9,7 @@
             "parameters": {
                 "app": "Drupal",
                 "hostname": "realize.be",
-                "existing-account-uri": "acct:swental@realize.be",
+                "existing-account-uri": "acct:swentel@realize.be",
                 "nonexisting-account-uri": "acct:does-not-exist@realize.be"
             }
         }

--- a/production/nodes/drupal-acct_swental@realize.be.json
+++ b/production/nodes/drupal-acct_swental@realize.be.json
@@ -3,7 +3,7 @@
     "parameters": {
         "app": "Drupal",
         "hostname": "realize.be",
-        "existing-account-uri": "acct:swental@realize.be",
+        "existing-account-uri": "acct:swentel@realize.be",
         "nonexisting-account-uri": "acct:does-not-exist@realize.be"
     }
 }

--- a/production/session-templates/webfinger-server-all.json
+++ b/production/session-templates/webfinger-server-all.json
@@ -24,7 +24,7 @@
             "skip": null
         },
         {
-            "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri",
+            "name": "webfinger.server.4_2__2_perform_query::normal_query",
             "rolemapping": {
                 "client": "client",
                 "server": "server"
@@ -32,7 +32,7 @@
             "skip": null
         },
         {
-            "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals",
+            "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
             "rolemapping": {
                 "client": "client",
                 "server": "server"
@@ -40,7 +40,39 @@
             "skip": null
         },
         {
-            "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri",
+            "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
+            "rolemapping": {
+                "client": "client",
+                "server": "server"
+            },
+            "skip": null
+        },
+        {
+            "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
+            "rolemapping": {
+                "client": "client",
+                "server": "server"
+            },
+            "skip": null
+        },
+        {
+            "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
+            "rolemapping": {
+                "client": "client",
+                "server": "server"
+            },
+            "skip": null
+        },
+        {
+            "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
+            "rolemapping": {
+                "client": "client",
+                "server": "server"
+            },
+            "skip": null
+        },
+        {
+            "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
             "rolemapping": {
                 "client": "client",
                 "server": "server"
@@ -49,6 +81,14 @@
         },
         {
             "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
+            "rolemapping": {
+                "client": "client",
+                "server": "server"
+            },
+            "skip": null
+        },
+        {
+            "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
             "rolemapping": {
                 "client": "client",
                 "server": "server"
@@ -88,15 +128,7 @@
             "skip": null
         },
         {
-            "name": "webfinger.server.4__2_returns_valid_jrd::returns_valid_jrd",
-            "rolemapping": {
-                "client": "client",
-                "server": "server"
-            },
-            "skip": null
-        },
-        {
-            "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::only_returns_jrd_in_response_to_https",
+            "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
             "rolemapping": {
                 "client": "client",
                 "server": "server"

--- a/production/testplans/webfinger-server-all-wellknown-saas-imp.json
+++ b/production/testplans/webfinger-server-all-wellknown-saas-imp.json
@@ -23,104 +23,136 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri",
+                    "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
-                    },
-                    "skip": null
-                },
-                {
-                    "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::returns_jrd_in_response_to_https",
-                    "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
@@ -150,104 +182,136 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri",
+                    "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
-                    },
-                    "skip": null
-                },
-                {
-                    "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::returns_jrd_in_response_to_https",
-                    "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
@@ -277,104 +341,136 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri",
+                    "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
-                    },
-                    "skip": null
-                },
-                {
-                    "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::returns_jrd_in_response_to_https",
-                    "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
@@ -404,104 +500,136 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri",
+                    "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
-                    },
-                    "skip": null
-                },
-                {
-                    "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::returns_jrd_in_response_to_https",
-                    "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
@@ -531,104 +659,136 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri",
+                    "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
-                    },
-                    "skip": null
-                },
-                {
-                    "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::returns_jrd_in_response_to_https",
-                    "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
@@ -658,104 +818,136 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri",
+                    "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
-                    },
-                    "skip": null
-                },
-                {
-                    "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::returns_jrd_in_response_to_https",
-                    "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
@@ -774,7 +966,7 @@
                         "parameters": {
                             "app": "Drupal",
                             "hostname": "realize.be",
-                            "existing-account-uri": "acct:swental@realize.be",
+                            "existing-account-uri": "acct:swentel@realize.be",
                             "nonexisting-account-uri": "acct:does-not-exist@realize.be"
                         }
                     }
@@ -785,104 +977,136 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri",
+                    "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
-                    },
-                    "skip": null
-                },
-                {
-                    "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::returns_jrd_in_response_to_https",
-                    "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
@@ -912,104 +1136,136 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri",
+                    "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
-                    },
-                    "skip": null
-                },
-                {
-                    "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::returns_jrd_in_response_to_https",
-                    "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
@@ -1039,104 +1295,136 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri",
+                    "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
-                    },
-                    "skip": null
-                },
-                {
-                    "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::returns_jrd_in_response_to_https",
-                    "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
@@ -1166,104 +1454,136 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri",
+                    "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
-                    },
-                    "skip": null
-                },
-                {
-                    "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::returns_jrd_in_response_to_https",
-                    "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
@@ -1293,104 +1613,136 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri",
+                    "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
-                    },
-                    "skip": null
-                },
-                {
-                    "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::returns_jrd_in_response_to_https",
-                    "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
@@ -1420,104 +1772,136 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri",
+                    "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
-                    },
-                    "skip": null
-                },
-                {
-                    "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::returns_jrd_in_response_to_https",
-                    "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
@@ -1547,104 +1931,136 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri",
+                    "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
-                    },
-                    "skip": null
-                },
-                {
-                    "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::returns_jrd_in_response_to_https",
-                    "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
@@ -1674,104 +2090,136 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri",
+                    "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
-                    },
-                    "skip": null
-                },
-                {
-                    "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::returns_jrd_in_response_to_https",
-                    "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
@@ -1801,104 +2249,136 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri",
+                    "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
-                    },
-                    "skip": null
-                },
-                {
-                    "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::returns_jrd_in_response_to_https",
-                    "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
@@ -1928,104 +2408,136 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri",
+                    "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
-                    },
-                    "skip": null
-                },
-                {
-                    "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::returns_jrd_in_response_to_https",
-                    "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
@@ -2055,104 +2567,136 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri",
+                    "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
-                    },
-                    "skip": null
-                },
-                {
-                    "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::returns_jrd_in_response_to_https",
-                    "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
@@ -2182,104 +2726,136 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri",
+                    "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
-                    },
-                    "skip": null
-                },
-                {
-                    "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::returns_jrd_in_response_to_https",
-                    "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
@@ -2309,104 +2885,136 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri",
+                    "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
-                    },
-                    "skip": null
-                },
-                {
-                    "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::returns_jrd_in_response_to_https",
-                    "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
@@ -2436,104 +3044,136 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri",
+                    "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
-                    },
-                    "skip": null
-                },
-                {
-                    "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::returns_jrd_in_response_to_https",
-                    "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
@@ -2563,104 +3203,136 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri",
+                    "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
-                    },
-                    "skip": null
-                },
-                {
-                    "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::returns_jrd_in_response_to_https",
-                    "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
@@ -2690,104 +3362,136 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri",
+                    "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
-                    },
-                    "skip": null
-                },
-                {
-                    "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::returns_jrd_in_response_to_https",
-                    "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
@@ -2817,104 +3521,136 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri",
+                    "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
-                    },
-                    "skip": null
-                },
-                {
-                    "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::returns_jrd_in_response_to_https",
-                    "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
@@ -2944,104 +3680,136 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri",
+                    "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
-                    },
-                    "skip": null
-                },
-                {
-                    "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::returns_jrd_in_response_to_https",
-                    "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
@@ -3071,104 +3839,136 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri",
+                    "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
-                    },
-                    "skip": null
-                },
-                {
-                    "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::returns_jrd_in_response_to_https",
-                    "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
@@ -3198,104 +3998,136 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri",
+                    "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
-                    },
-                    "skip": null
-                },
-                {
-                    "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::returns_jrd_in_response_to_https",
-                    "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
@@ -3325,104 +4157,136 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri",
+                    "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
-                    },
-                    "skip": null
-                },
-                {
-                    "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::returns_jrd_in_response_to_https",
-                    "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
@@ -3452,104 +4316,136 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri",
+                    "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
-                    },
-                    "skip": null
-                },
-                {
-                    "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::returns_jrd_in_response_to_https",
-                    "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
@@ -3579,104 +4475,136 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri",
+                    "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
-                    },
-                    "skip": null
-                },
-                {
-                    "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::returns_jrd_in_response_to_https",
-                    "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
@@ -3706,104 +4634,136 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri",
+                    "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
-                    },
-                    "skip": null
-                },
-                {
-                    "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::returns_jrd_in_response_to_https",
-                    "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
@@ -3833,104 +4793,136 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri",
+                    "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
-                    },
-                    "skip": null
-                },
-                {
-                    "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::returns_jrd_in_response_to_https",
-                    "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
@@ -3960,104 +4952,136 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri",
+                    "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
-                    },
-                    "skip": null
-                },
-                {
-                    "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::returns_jrd_in_response_to_https",
-                    "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
@@ -4087,104 +5111,136 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri",
+                    "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
-                    },
-                    "skip": null
-                },
-                {
-                    "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::returns_jrd_in_response_to_https",
-                    "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
@@ -4214,104 +5270,136 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri",
+                    "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
-                    },
-                    "skip": null
-                },
-                {
-                    "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::returns_jrd_in_response_to_https",
-                    "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
@@ -4341,104 +5429,136 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri",
+                    "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
-                    },
-                    "skip": null
-                },
-                {
-                    "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::returns_jrd_in_response_to_https",
-                    "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
@@ -4468,104 +5588,136 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri",
+                    "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
-                    },
-                    "skip": null
-                },
-                {
-                    "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::returns_jrd_in_response_to_https",
-                    "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
@@ -4595,104 +5747,136 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri",
+                    "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
-                    },
-                    "skip": null
-                },
-                {
-                    "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::returns_jrd_in_response_to_https",
-                    "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
@@ -4722,104 +5906,136 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri",
+                    "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
-                    },
-                    "skip": null
-                },
-                {
-                    "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::returns_jrd_in_response_to_https",
-                    "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
@@ -4849,104 +6065,136 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri",
+                    "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
-                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri",
+                    "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
+                    },
+                    "skip": null
+                },
+                {
+                    "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
+                    "rolemapping": {
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
-                    },
-                    "skip": null
-                },
-                {
-                    "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::returns_jrd_in_response_to_https",
-                    "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }

--- a/tests/webfinger/TEST-SOURCES/index-annost.html
+++ b/tests/webfinger/TEST-SOURCES/index-annost.html
@@ -673,9 +673,8 @@ Server produces the same response regardless of parameter ordering.
 The client issues the query to the right URI.
 Tested there already.
 </annost-xref>
-<annost-note>
-   4.2/2 removed, didn't do much
-</annost-note>
+<annost-test testid="4.2/2" name="Perform a normal query" role="Server" level="MUST">
+</annost-test>
 <annost-xref target="4/4">
 Resource parameter (client)
 </annost-xref>
@@ -773,10 +772,10 @@ of a query when it shouldn't?
    <a href="#section-10.2">10.2</a>).
 
 </pre>
-<annost-xref target="4/3">
-A server must return the <code>application/jrd+json</code> content type.
-We test this already and don't need 4.2/9.
-</annost-xref>
+<annost-test testid="4.2/9" name="Server must return JRD content type" role="Server" level="MUST">
+    A server must return the <code>application/jrd+json</code> content type.
+</annost-test>
+
 <pre>
    The properties, titles, and link relation types returned by the
    server in a JRD might be varied and numerous.  For example, the
@@ -1331,7 +1330,8 @@ Already tested there.
 </pre>
 <annost-test testid="4.5/1" name="Any URI scheme for resource identifiers" role="Server" level="MUST">
 The server must accept resource identifiers provided in the query that use any scheme.
-The server must but returns a "404 not found" for URI schemes it does not understand.
+It appears that this implies it must return "404 not found" for URI schemes it does not understand.
+(It accepts the query, so it can't be 400, but has no knowledge about the acct.)
 </annost-test>
 <pre>
 

--- a/tests/webfinger/server/4_1__2_parameter_ordering_not_significant.py
+++ b/tests/webfinger/server/4_1__2_parameter_ordering_not_significant.py
@@ -1,7 +1,10 @@
 from hamcrest import any_of, equal_to, starts_with
 
-from feditest import SkipTestException, hard_assert_that, test
+from feditest import hard_assert_that, test
+from feditest.protocols.web import WebClient
 from feditest.protocols.webfinger import WebFingerClient, WebFingerServer
+from feditest.protocols.webfinger.traffic import ClaimedJrd
+from feditest.protocols.webfinger.utils import none_except, recursive_equal_to, wf_error
 
 RELS = [
     'http://webfinger.net/rel/profile-page',
@@ -23,16 +26,16 @@ def parameter_ordering(
     for i in range(0, len(RELS)):
         rels = RELS[i:] + RELS[0:i]
         webfinger_response = client.perform_webfinger_query(test_id, rels)
-
-        hard_assert_that(webfinger_response.http_request_response_pair.response.http_status, equal_to(200), 'Not HTTP status 200')
-        hard_assert_that(webfinger_response.http_request_response_pair.response.response_headers.get('content-type'),
-            any_of(
-                equal_to('application/jrd+json'),
-                starts_with('application/jrd+json;')),
-            'Not content of type JRD')
+        hard_assert_that(
+                webfinger_response.exc,
+                none_except(WebClient.WrongContentTypeError, ClaimedJrd.InvalidMediaTypeError, ClaimedJrd.InvalidRelError),
+                wf_error(webfinger_response))
 
         if i == 0:
             first_webfinger_response = webfinger_response
         else:
-            hard_assert_that(webfinger_response, equal_to(first_webfinger_response), f'Response {i} not same as 1st')
-
+            hard_assert_that(
+                    webfinger_response.jrd, recursive_equal_to(first_webfinger_response.jrd),
+                    f'Response {i} not same.\n'
+                    + f'Accessed URIs: "{ webfinger_response.http_request_response_pair.request.uri.get_uri() }"'
+                    + f' vs "{ first_webfinger_response.http_request_response_pair.request.uri.get_uri() }".')

--- a/tests/webfinger/server/4_2__14_must_only_redirect_to_https.py
+++ b/tests/webfinger/server/4_2__14_must_only_redirect_to_https.py
@@ -16,4 +16,9 @@ def must_only_redirect_to_https(
     test_id = server.obtain_account_identifier()
 
     response : WebFingerQueryResponse = client.perform_webfinger_query(test_id)
-    hard_assert_that(response.http_request_response_pair.final_request.uri.scheme, equal_to('https'), 'Not https')
+    hard_assert_that(
+            response.http_request_response_pair.final_request.uri.scheme,
+            equal_to('https'),
+            f'Not https.\n'
+            + 'Identifier: "{ test_id }" leads to'
+            + f' final request URI { response.http_request_response_pair.final_request.uri.get_uri() }.')

--- a/tests/webfinger/server/4_2__2_perform_query.py
+++ b/tests/webfinger/server/4_2__2_perform_query.py
@@ -1,0 +1,33 @@
+from hamcrest import none, not_none
+
+from feditest import hard_assert_that, test
+from feditest.protocols.webfinger import WebFingerClient, WebFingerServer
+from feditest.protocols.webfinger.utils import wf_error
+
+@test
+def normal_query(
+        client: WebFingerClient,
+        server: WebFingerServer
+) -> None:
+    """
+    Parameter ordering is not significant.
+    """
+    test_id = server.obtain_account_identifier()
+
+    webfinger_response = client.perform_webfinger_query(test_id)
+
+    hard_assert_that(
+            webfinger_response.exc,
+            none(),
+            wf_error(webfinger_response))
+
+    hard_assert_that(
+            webfinger_response.jrd,
+            not_none(),
+            wf_error(webfinger_response))
+
+    try:
+        webfinger_response.jrd.validate()
+
+    except Exception as e:
+        hard_assert_that(False, wf_error(webfinger_response))

--- a/tests/webfinger/server/4_2__3_requires_resource_uri.py
+++ b/tests/webfinger/server/4_2__3_requires_resource_uri.py
@@ -1,3 +1,5 @@
+from json import JSONDecodeError
+
 from feditest import hard_assert_that, test
 from feditest.protocols.web.traffic import HttpResponse
 from feditest.protocols.webfinger import WebFingerClient, WebFingerServer
@@ -6,28 +8,19 @@ from hamcrest import (
     any_of,
     calling,
     equal_to,
-    greater_than_or_equal_to,
     is_not,
     raises,
     starts_with,
 )
 
 
-def interpret_payload_as_jrd(payload: str):
-    """
-    Helper
-    """
-    jrd = ClaimedJrd(payload)
-    jrd.validate()
-
-
 @test
-def requires_resource_uri(
+def requires_resource_uri_http_status(
         client: WebFingerClient,
         server: WebFingerServer
 ) -> None:
     """
-    Do not accept requests with missing resource parameter.
+    Do not accept requests with missing resource parameter: HTTP status.
     """
     test_id = server.obtain_account_identifier()
 
@@ -37,16 +30,40 @@ def requires_resource_uri(
     uri_without = correct_webfinger_uri[0:q]
 
     response_without : HttpResponse = client.http_get(uri_without).response
-    hard_assert_that(response_without.http_status, equal_to(400), 'Not HTTP status 400')
+    hard_assert_that(
+            response_without.http_status,
+            equal_to(400),
+            f'Not HTTP status 400.\nAccessed URI: "{ uri_without }".')
+
+
+@test
+def requires_resource_uri_jrd(
+        client: WebFingerClient,
+        server: WebFingerServer
+) -> None:
+    """
+    Do not accept requests with missing resource parameter: JRD content.
+    """
+    test_id = server.obtain_account_identifier()
+
+    correct_webfinger_uri = client.construct_webfinger_uri_for(test_id)
+    q = correct_webfinger_uri.find('?resource=')
+    assert(q>0)
+    uri_without = correct_webfinger_uri[0:q]
+
+    response_without : HttpResponse = client.http_get(uri_without).response
 
     content_type = response_without.response_headers.get('content-type', "")
-    hard_assert_that(content_type,
-        is_not(any_of(
-                equal_to('application/jrd+json'),
-                starts_with('application/jrd+json;'))),
-        "Provided content of type JRD anyway")
-    if "application/json" in content_type:
-        hard_assert_that(calling(
-                lambda: interpret_payload_as_jrd(response_without.payload)),
-                raises(RuntimeError),
-            "Provided JRD anyway")
+    hard_assert_that(
+            content_type,
+            is_not( any_of(
+                    equal_to('application/jrd+json'),
+                    starts_with('application/jrd+json;'))),
+            f'Returns JRD content.\nAccessed URI: "{ uri_without }".')
+
+    if content_type.startswith('application/json'):
+        hard_assert_that(
+                calling(lambda: ClaimedJrd.create_and_validate(response_without.payload)),
+                any_of( raises(RuntimeError),
+                        raises(JSONDecodeError)),
+                f'Returns JRD content.\nAccessed URI: "{ uri_without }".')

--- a/tests/webfinger/server/4_2__4_do_not_accept_malformed_resource_parameters.py
+++ b/tests/webfinger/server/4_2__4_do_not_accept_malformed_resource_parameters.py
@@ -1,17 +1,21 @@
-from hamcrest import all_of, equal_to, greater_than_or_equal_to, less_than
+from json import JSONDecodeError
 import urllib
+
+from hamcrest import all_of, equal_to, greater_than_or_equal_to, less_than
 
 from feditest import hard_assert_that, soft_assert_that, test
 from feditest.protocols.web.traffic import HttpResponse
 from feditest.protocols.webfinger import WebFingerClient, WebFingerServer
+from feditest.protocols.webfinger.traffic import ClaimedJrd
+
 
 @test
-def requires_valid_resource_uri(
+def requires_valid_resource_uri_http_status(
         client: WebFingerClient,
         server: WebFingerServer
 ) -> None:
     """
-    Do not accept malformed resource parameters. Test missing acct: scheme.
+    Do not accept malformed resource parameters. Test HTTP status for missing acct: scheme.
     """
     # We use the lower-level API from WebClient because we can't make the WebFingerClient do something invalid
     test_id : str = server.obtain_account_identifier()
@@ -21,22 +25,57 @@ def requires_valid_resource_uri(
     malformed_webfinger_uri : str = f"https://{hostname}/.well-known/webfinger?resource={test_id_no_scheme}"
 
     response : HttpResponse = client.http_get(malformed_webfinger_uri).response
-
-    hard_assert_that(response.http_status,
+    soft_assert_that(
+            response.http_status,
 			all_of(
                 greater_than_or_equal_to(400),
                 less_than(500)),
-			'Not HTTP status 4xx')
-    soft_assert_that(response.http_status, equal_to(400), 'Not HTTP status 400')
+			f'Not HTTP status 4xx.\nAccessed URI: "{ malformed_webfinger_uri }".')
+    soft_assert_that(
+            response.http_status,
+            equal_to(400),
+            f'Not HTTP status 400\nAccessed URI: "{ malformed_webfinger_uri }".')
 
 
 @test
-def double_equals(
+def requires_valid_resource_uri_jrd(
         client: WebFingerClient,
         server: WebFingerServer
 ) -> None:
     """
-    Do not accept malformed resource parameters. Insert an extra = character.
+    Do not accept malformed resource parameters. Test JRD content for missing acct: scheme.
+    """
+    # We use the lower-level API from WebClient because we can't make the WebFingerClient do something invalid
+    test_id : str = server.obtain_account_identifier()
+    hostname : str = server.hostname
+
+    test_id_no_scheme = test_id.replace("acct:", "")
+    malformed_webfinger_uri : str = f"https://{hostname}/.well-known/webfinger?resource={test_id_no_scheme}"
+
+    response : HttpResponse = client.http_get(malformed_webfinger_uri).response
+    try: # we do not use the pyhamcrest any_of(raises, raises) because the error message is incomprehensible
+        ClaimedJrd.create_and_validate(response.payload)
+
+        soft_assert_that(False, f'Returns JRD content.\nAccessed URI: "{ malformed_webfinger_uri }".')
+
+    except ExceptionGroup as exc:
+        for e in exc.exceptions:
+            if not isinstance(e, (RuntimeError, JSONDecodeError)):
+                raise exc
+        pass # expected
+    except RuntimeError:
+        pass # expected
+    except JSONDecodeError:
+        pass # expected
+
+
+@test
+def double_equals_http_status(
+        client: WebFingerClient,
+        server: WebFingerServer
+) -> None:
+    """
+    Do not accept malformed resource parameters. Test HTTP status for inserting an extra = character.
     """
     # We use the lower-level API from WebClient because we can't make the WebFingerClient do something invalid
     test_id = server.obtain_account_identifier()
@@ -45,10 +84,44 @@ def double_equals(
     malformed_webfinger_uri = f"https://{hostname}/.well-known/webfinger?resource=={urllib.parse.quote(test_id)}"
 
     response : HttpResponse = client.http_get(malformed_webfinger_uri).response
-
-    hard_assert_that(response.http_status,
+    hard_assert_that(
+            response.http_status,
 			all_of(
                 greater_than_or_equal_to(400),
                 less_than(500)),
-			'Not HTTP status 4xx')
-    soft_assert_that(response.http_status, equal_to(400), 'Not HTTP status 400')
+			f'Not HTTP status 4xx.\nAccessed URI: "{ malformed_webfinger_uri }".')
+    soft_assert_that(
+            response.http_status,
+            equal_to(400),
+            f'Not HTTP status 400\nAccessed URI: "{ malformed_webfinger_uri }".')
+
+
+@test
+def double_equals_jrd(
+        client: WebFingerClient,
+        server: WebFingerServer
+) -> None:
+    """
+    Do not accept malformed resource parameters. Test JRD content for inserting an extra = character.
+    """
+    # We use the lower-level API from WebClient because we can't make the WebFingerClient do something invalid
+    test_id = server.obtain_account_identifier()
+    hostname : str = server.hostname
+
+    malformed_webfinger_uri = f"https://{hostname}/.well-known/webfinger?resource=={urllib.parse.quote(test_id)}"
+
+    response : HttpResponse = client.http_get(malformed_webfinger_uri).response
+    try: # we do not use the pyhamcrest any_of(raises, raises) because the error message is incomprehensible
+        ClaimedJrd.create_and_validate(response.payload)
+
+        soft_assert_that(False, f'Returns JRD content.\nAccessed URI: "{ malformed_webfinger_uri }".')
+
+    except ExceptionGroup as exc:
+        for e in exc.exceptions:
+            if not isinstance(e, (RuntimeError, JSONDecodeError)):
+                raise exc
+        pass # expected
+    except RuntimeError:
+        pass # expected
+    except JSONDecodeError:
+        pass # expected

--- a/tests/webfinger/server/4_2__5_status_404_for_nonexisting_resources.py
+++ b/tests/webfinger/server/4_2__5_status_404_for_nonexisting_resources.py
@@ -17,4 +17,7 @@ def status_404_for_nonexisting_resources(
     webfinger_uri = client.construct_webfinger_uri_for(test_id)
 
     response : HttpResponse = client.http_get(webfinger_uri).response
-    hard_assert_that(response.http_status, equal_to(404), 'Not HTTP status 404')
+    hard_assert_that(
+            response.http_status,
+            equal_to(404),
+            f'Not HTTP status 404.\nAccessed URI: "{ webfinger_uri }".')

--- a/tests/webfinger/server/4_2__9_content_type.py
+++ b/tests/webfinger/server/4_2__9_content_type.py
@@ -1,0 +1,30 @@
+from hamcrest import any_of, equal_to, is_not, starts_with
+
+from feditest import test, hard_assert_that
+from feditest.protocols.web.traffic import HttpResponse
+from feditest.protocols.webfinger import WebFingerClient, WebFingerServer
+
+@test
+def returns_jrd_in_response_to_https(
+        client: WebFingerClient,
+        server: WebFingerServer
+) -> None:
+    """
+    Test that a query over HTTPS produces a JRD.
+    """
+    test_id = server.obtain_account_identifier()
+
+    correct_webfinger_uri = client.construct_webfinger_uri_for(test_id)
+    hard_assert_that(correct_webfinger_uri, starts_with('https://'))
+
+    correct_https_response : HttpResponse = client.http_get(correct_webfinger_uri).response
+    hard_assert_that(
+            correct_https_response.http_status,
+            equal_to(200),
+            f'Not HTTP status 200.\nAccessed URI: "{ correct_webfinger_uri }".')
+    hard_assert_that(
+            correct_https_response.response_headers.get('content-type'),
+            any_of(
+                    equal_to('application/jrd+json'),
+                    starts_with('application/jrd+json;')),
+            f'Wrong content type.\nAccessed URI: "{ correct_webfinger_uri }".')

--- a/tests/webfinger/server/4_5__1_any_uri_scheme_for_resource_identifiers.py
+++ b/tests/webfinger/server/4_5__1_any_uri_scheme_for_resource_identifiers.py
@@ -12,7 +12,7 @@ def any_uri_scheme_for_resource_identifiers(
         server: WebFingerServer
 ) -> None:
     """
-    The server must but returns a "404 not found" for URI schemes it does not understand.
+    The server must accept resource identifiers provided in the query that use any scheme.
     """
     # We use the lower-level API from WebClient because we can't make the WebFingerClient do something
     # with a scheme it does not understand
@@ -22,5 +22,8 @@ def any_uri_scheme_for_resource_identifiers(
         url : str = f"https://{ hostname }/.well-known/webfinger?resource={ quote(test_id) }"
 
         response : HttpResponse = client.http_get(url).response
-        soft_assert_that(response.http_status, equal_to(404), 'Not HTTP status 404')
+        soft_assert_that(
+                response.http_status,
+                equal_to(404),
+                f'Not HTTP status 404.\nAccessed URI: "{ url }".')
 

--- a/tests/webfinger/server/4__1_accepts_all_link_rels_in_query.py
+++ b/tests/webfinger/server/4__1_accepts_all_link_rels_in_query.py
@@ -1,9 +1,9 @@
 from feditest import hard_assert_that, test
+from feditest.protocols.web import WebClient
 from feditest.protocols.webfinger import WebFingerClient, WebFingerServer
-from feditest.protocols.webfinger.traffic import WebFingerQueryResponse
-from feditest.protocols.webfinger.utils import link_subset_or_equal_to
+from feditest.protocols.webfinger.traffic import ClaimedJrd, WebFingerQueryResponse
+from feditest.protocols.webfinger.utils import link_subset_or_equal_to, none_except, wf_error
 from feditest.reporting import info
-from hamcrest import equal_to
 
 # Note: we do not try all the known rel values, only the ones known to be used in a webfinger context
 # See also https://fedidevs.org/reference/webfinger/
@@ -28,7 +28,7 @@ KNOWN_RELS = [ # known to be used in webfinger files
 #    'http://specs.openid.net/auth/2.0/provider',
 #    'http://webfinger.net/rel/avatar',
 #    'http://webfinger.net/rel/blog',
-#    'http://webfinger.net/rel/profile-page',
+    'http://webfinger.net/rel/profile-page',
 
 #    'describedby',
 #    'diaspora-public-key',
@@ -56,11 +56,23 @@ def accepts_known_link_rels_in_query(
     """
     test_id = server.obtain_account_identifier()
     response_without_rel : WebFingerQueryResponse = client.perform_webfinger_query(test_id)
+    hard_assert_that(
+            response_without_rel.exc,
+            none_except(WebClient.WrongContentTypeError, ClaimedJrd.InvalidMediaTypeError, ClaimedJrd.InvalidRelError),
+            wf_error(response_without_rel))
+
     for rel in KNOWN_RELS:
         info(f'WebFinger query for resource "{test_id}" with rel "{rel}"')
         response_with_rel : WebFingerQueryResponse = client.perform_webfinger_query(test_id, [rel])
-        hard_assert_that(response_with_rel.http_request_response_pair.response.http_status, equal_to(200))
-        hard_assert_that(response_with_rel.jrd, link_subset_or_equal_to(response_without_rel.jrd))
+        hard_assert_that(
+                response_without_rel.exc,
+                none_except(WebClient.WrongContentTypeError, ClaimedJrd.InvalidMediaTypeError, ClaimedJrd.InvalidRelError),
+                wf_error(response_with_rel))
+        hard_assert_that(
+                response_with_rel.jrd,
+                link_subset_or_equal_to(response_without_rel.jrd),
+                'Not same or subset of links.'
+                + f'\nAccessed URI: "{ response_with_rel.http_request_response_pair.request.uri.get_uri() }" with rel { rel } vs none.' )
 
 
 @test
@@ -75,10 +87,22 @@ def accepts_unknown_link_rels_in_query(
     test_id = server.obtain_account_identifier()
 
     response_without_rel = client.perform_webfinger_query(test_id)
+    hard_assert_that(
+            response_without_rel.exc,
+            none_except(WebClient.WrongContentTypeError, ClaimedJrd.InvalidMediaTypeError, ClaimedJrd.InvalidRelError),
+            wf_error(response_without_rel))
+
     for rel in UNKNOWN_RELS:
         response_with_rel = client.perform_webfinger_query(test_id, [rel])
-        hard_assert_that(response_with_rel.http_request_response_pair.response.http_status, equal_to(200))
-        hard_assert_that(response_with_rel.jrd, link_subset_or_equal_to(response_without_rel.jrd))
+        hard_assert_that(
+                response_without_rel.exc,
+                none_except(WebClient.WrongContentTypeError, ClaimedJrd.InvalidMediaTypeError, ClaimedJrd.InvalidRelError),
+                wf_error(response_with_rel))
+        hard_assert_that(
+                response_with_rel.jrd,
+                link_subset_or_equal_to(response_without_rel.jrd),
+                'Not same or subset of links.'
+                + f'\nAccessed URI: "{ response_with_rel.http_request_response_pair.request.uri.get_uri() }" with rel { rel } vs none.' )
 
 
 @test
@@ -93,15 +117,24 @@ def accepts_combined_link_rels_in_query(
     test_id = server.obtain_account_identifier()
 
     response_without_rel = client.perform_webfinger_query(test_id)
+    hard_assert_that(
+            response_without_rel.exc,
+            none_except(WebClient.WrongContentTypeError, ClaimedJrd.InvalidMediaTypeError, ClaimedJrd.InvalidRelError),
+            wf_error(response_without_rel))
+
     count = 0
     for rel1 in KNOWN_RELS:
         for rel2 in UNKNOWN_RELS:
             rels = [rel1, rel2] if count % 2 else [rel2, rel1]
             response_with_rel = client.perform_webfinger_query(test_id, rels)
-            hard_assert_that(response_with_rel.http_request_response_pair.response.http_status,
-                             equal_to(200),
-                             'Not HTTP status 200')
-            hard_assert_that(response_with_rel.jrd,
-                             link_subset_or_equal_to(response_without_rel.jrd),
-                             'Not the same or subset of links')
+            hard_assert_that(
+                    response_without_rel.exc,
+                    none_except(WebClient.WrongContentTypeError, ClaimedJrd.InvalidMediaTypeError, ClaimedJrd.InvalidRelError),
+                    wf_error(response_with_rel))
+            hard_assert_that(
+                    response_with_rel.jrd,
+                    link_subset_or_equal_to(response_without_rel.jrd),
+                    'Not same or subset of links.'
+                    + f'\nAccessed URI: "{ response_with_rel.http_request_response_pair.request.uri.get_uri() }"'
+                    + f' with rels { rels[0] } and { rels[1] } vs none.' )
             count += 1

--- a/tests/webfinger/server/4__3_only_returns_jrd_in_response_to_https_requests.py
+++ b/tests/webfinger/server/4__3_only_returns_jrd_in_response_to_https_requests.py
@@ -4,27 +4,6 @@ from feditest import test, hard_assert_that
 from feditest.protocols.web.traffic import HttpResponse
 from feditest.protocols.webfinger import WebFingerClient, WebFingerServer
 
-@test
-def returns_jrd_in_response_to_https(
-        client: WebFingerClient,
-        server: WebFingerServer
-) -> None:
-    """
-    Test that a query over HTTPS produces a JRD.
-    """
-    test_id = server.obtain_account_identifier()
-
-    correct_webfinger_uri = client.construct_webfinger_uri_for(test_id)
-    hard_assert_that(correct_webfinger_uri, starts_with('https://'))
-
-    correct_https_response : HttpResponse = client.http_get(correct_webfinger_uri).response
-    hard_assert_that(correct_https_response.http_status, equal_to(200))
-    hard_assert_that(correct_https_response.response_headers.get('content-type'),
-        any_of(
-                equal_to('application/jrd+json'),
-                starts_with('application/jrd+json;')),
-        'Not content of type JRD')
-
 
 @test
 def does_not_return_jrd_in_response_to_http(
@@ -37,15 +16,22 @@ def does_not_return_jrd_in_response_to_http(
     test_id = server.obtain_account_identifier()
 
     correct_webfinger_uri = client.construct_webfinger_uri_for(test_id)
-    hard_assert_that(correct_webfinger_uri, starts_with('https://'))
+    hard_assert_that(
+            correct_webfinger_uri,
+            starts_with('https://'),
+            f'Incorrect WebFinger URI.')
 
     http_webfinger_uri = correct_webfinger_uri.replace('https:', 'http:')
     assert(http_webfinger_uri.startswith('http://'))
 
     http_response : HttpResponse = client.http_get(http_webfinger_uri, follow_redirects=False).response
-    hard_assert_that(http_response.http_status, is_not(equal_to(200)))
-    hard_assert_that(http_response.response_headers.get('content-type'),
-        is_not(any_of(
-                equal_to('application/jrd+json'),
-                starts_with('application/jrd+json;'))),
-        'Return content of type JRD anyway')
+    hard_assert_that(
+            http_response.http_status,
+            is_not(equal_to(200)),
+            f'HTTP status 200.\nAccessed URI: "{ http_webfinger_uri }".')
+    hard_assert_that(
+            http_response.response_headers.get('content-type'),
+            is_not(any_of(
+                    equal_to('application/jrd+json'),
+                    starts_with('application/jrd+json;'))),
+            f'Returns JRD content.\nAccessed URI: "{ http_webfinger_uri }".')

--- a/tests/webfinger/server/5_1_cors_header_required.py
+++ b/tests/webfinger/server/5_1_cors_header_required.py
@@ -1,5 +1,5 @@
 from feditest import hard_assert_that, test
-from feditest.protocols.web.traffic import HttpResponse
+from feditest.protocols.web.traffic import HttpRequestResponsePair
 from feditest.protocols.webfinger import WebFingerClient, WebFingerServer
 from feditest.protocols.webfinger.utils import multi_dict_has_key
 
@@ -14,9 +14,9 @@ def cors_header_required(
     """
     test_id = server.obtain_account_identifier()
 
-    response : HttpResponse = client.perform_webfinger_query(test_id).http_request_response_pair.response
+    pair : HttpRequestResponsePair = client.perform_webfinger_query(test_id).http_request_response_pair
 
     hard_assert_that(
-        'access-control-allow-origin' in response.response_headers,
-        "Missing access-control-allow-origin header")
+        'access-control-allow-origin' in pair.response.response_headers,
+        f'Missing CORS header.\nAccessed URI: "{ pair.request.uri.get_uri() }".\nNot present: "access-control-allow-origin".')
     # FIXME not checking for a correct value. How?


### PR DESCRIPTION
* Reviewed the results of the default webfinger testplan for some servers
* Added a few tests
* Better and more consistent error reporting.
* Do not report some errors in tests that aren't focusing on that particular error, but other tests are
* Test at least two link rels
* Avoid pyhamcrest any_of(raises, raises) as it has an incomprehensible error message
* Split some tests so subsequent errors can be shown, too
* Fix typo in the Drupal SaaS default account