### PR TITLE
Fix account identifier in nodes files

### DIFF
--- a/production/nodes/wildebeest-acct_cloudflare@cloudflare.social.json
+++ b/production/nodes/wildebeest-acct_cloudflare@cloudflare.social.json
@@ -3,7 +3,7 @@
     "parameters": {
         "app" : "Wildebeest",
         "hostname": "cloudflare.social",
-        "existing-account-uri": "acct:gargron@cloudflare.social",
+        "existing-account-uri": "acct:cloudflare@cloudflare.social",
         "nonexisting-account-uri": "acct:does-not-exist@cloudflare.social"
     }
 }


### PR DESCRIPTION
The checked-in constellation files are generated from the nodes files, so that's where the account identifier needs to be defined, see also #102.