### PR TITLE
Changed activitypubrelay to darmstadt.social

### DIFF
--- a/production/constellations/imp-vs-activityrelay-acct_relay@relay.darmstadt.social.json
+++ b/production/constellations/imp-vs-activityrelay-acct_relay@relay.darmstadt.social.json
@@ -8,9 +8,9 @@
             "nodedriver": "saas.SaasFediverseNodeDriver",
             "parameters": {
                 "app": "ActivityRelay",
-                "hostname": "relay.libranet.de",
-                "existing-account-uri": "acct:relay@relay.libranet.de",
-                "nonexisting-account-uri": "acct:does-not-exist@relay.libranet.de"
+                "hostname": "relay.darmstadt.social",
+                "existing-account-uri": "acct:relay@relay.darmstadt.social",
+                "nonexisting-account-uri": "acct:does-not-exist@relay.darmstadt.social"
             }
         }
     },

--- a/production/constellations/imp-vs-wildebeest-acct_cloudflare@cloudflare.social.json
+++ b/production/constellations/imp-vs-wildebeest-acct_cloudflare@cloudflare.social.json
@@ -9,7 +9,7 @@
             "parameters": {
                 "app": "Wildebeest",
                 "hostname": "cloudflare.social",
-                "existing-account-uri": "acct:gargron@cloudflare.social",
+                "existing-account-uri": "acct:cloudflare@cloudflare.social",
                 "nonexisting-account-uri": "acct:does-not-exist@cloudflare.social"
             }
         }

--- a/production/nodes/activityrelay-acct_relay@relay.darmstadt.social.json
+++ b/production/nodes/activityrelay-acct_relay@relay.darmstadt.social.json
@@ -1,0 +1,9 @@
+{
+    "nodedriver": "saas.SaasFediverseNodeDriver",
+    "parameters": {
+        "app": "ActivityRelay",
+        "hostname": "relay.darmstadt.social",
+        "existing-account-uri": "acct:relay@relay.darmstadt.social",
+        "nonexisting-account-uri": "acct:does-not-exist@relay.darmstadt.social"
+    }
+}

--- a/production/nodes/activityrelay-acct_relay@relay.libranet.de.json
+++ b/production/nodes/activityrelay-acct_relay@relay.libranet.de.json
@@ -1,9 +1,0 @@
-{
-    "nodedriver": "saas.SaasFediverseNodeDriver",
-    "parameters": {
-        "app": "ActivityRelay",
-        "hostname": "relay.libranet.de",
-        "existing-account-uri": "acct:relay@relay.libranet.de",
-        "nonexisting-account-uri": "acct:does-not-exist@relay.libranet.de"
-    }
-}

--- a/production/testplans/webfinger-server-all-wellknown-saas-imp.json
+++ b/production/testplans/webfinger-server-all-wellknown-saas-imp.json
@@ -11,9 +11,9 @@
                         "nodedriver": "saas.SaasFediverseNodeDriver",
                         "parameters": {
                             "app": "ActivityRelay",
-                            "hostname": "relay.libranet.de",
-                            "existing-account-uri": "acct:relay@relay.libranet.de",
-                            "nonexisting-account-uri": "acct:does-not-exist@relay.libranet.de"
+                            "hostname": "relay.darmstadt.social",
+                            "existing-account-uri": "acct:relay@relay.darmstadt.social",
+                            "nonexisting-account-uri": "acct:does-not-exist@relay.darmstadt.social"
                         }
                     }
                 },
@@ -23,141 +23,141 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
             ],
-            "name": "ActivityRelay"
+            "name": null
         },
         {
             "constellation": {
@@ -182,141 +182,141 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
             ],
-            "name": "Akkoma"
+            "name": null
         },
         {
             "constellation": {
@@ -341,141 +341,141 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
             ],
-            "name": "Bookwyrm"
+            "name": null
         },
         {
             "constellation": {
@@ -500,141 +500,141 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
             ],
-            "name": "Bridgy-Fed"
+            "name": null
         },
         {
             "constellation": {
@@ -659,141 +659,141 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
             ],
-            "name": "BuzzRelay"
+            "name": null
         },
         {
             "constellation": {
@@ -818,141 +818,141 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
             ],
-            "name": "Cherrypick"
+            "name": null
         },
         {
             "constellation": {
@@ -977,141 +977,141 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
             ],
-            "name": "Drupal"
+            "name": null
         },
         {
             "constellation": {
@@ -1136,141 +1136,141 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
             ],
-            "name": "Fedipage"
+            "name": null
         },
         {
             "constellation": {
@@ -1295,141 +1295,141 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
             ],
-            "name": "Forgejo"
+            "name": null
         },
         {
             "constellation": {
@@ -1454,141 +1454,141 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
             ],
-            "name": "Friendica"
+            "name": null
         },
         {
             "constellation": {
@@ -1613,141 +1613,141 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
             ],
-            "name": "Funkwhale"
+            "name": null
         },
         {
             "constellation": {
@@ -1772,141 +1772,141 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
             ],
-            "name": "Gancio"
+            "name": null
         },
         {
             "constellation": {
@@ -1931,141 +1931,141 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
             ],
-            "name": "Gitea"
+            "name": null
         },
         {
             "constellation": {
@@ -2090,141 +2090,141 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
             ],
-            "name": "GNU Social"
+            "name": null
         },
         {
             "constellation": {
@@ -2249,141 +2249,141 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
             ],
-            "name": "GoToSocial"
+            "name": null
         },
         {
             "constellation": {
@@ -2408,141 +2408,141 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
             ],
-            "name": "Hubzilla"
+            "name": null
         },
         {
             "constellation": {
@@ -2567,141 +2567,141 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
             ],
-            "name": "kbin"
+            "name": null
         },
         {
             "constellation": {
@@ -2726,141 +2726,141 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
             ],
-            "name": "Lemmy"
+            "name": null
         },
         {
             "constellation": {
@@ -2885,141 +2885,141 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
             ],
-            "name": "Mastodon"
+            "name": null
         },
         {
             "constellation": {
@@ -3044,141 +3044,141 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
             ],
-            "name": "Micro.blog"
+            "name": null
         },
         {
             "constellation": {
@@ -3203,141 +3203,141 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
             ],
-            "name": "Microblogpub"
+            "name": null
         },
         {
             "constellation": {
@@ -3362,141 +3362,141 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
             ],
-            "name": "Misskey"
+            "name": null
         },
         {
             "constellation": {
@@ -3521,141 +3521,141 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
             ],
-            "name": "Mitra"
+            "name": null
         },
         {
             "constellation": {
@@ -3680,141 +3680,141 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
             ],
-            "name": "Mobilizon"
+            "name": null
         },
         {
             "constellation": {
@@ -3839,141 +3839,141 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
             ],
-            "name": "NodeBB"
+            "name": null
         },
         {
             "constellation": {
@@ -3998,141 +3998,141 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
             ],
-            "name": "Owncast"
+            "name": null
         },
         {
             "constellation": {
@@ -4157,141 +4157,141 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
             ],
-            "name": "PeerTube"
+            "name": null
         },
         {
             "constellation": {
@@ -4316,141 +4316,141 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
             ],
-            "name": "Pixelfed"
+            "name": null
         },
         {
             "constellation": {
@@ -4475,141 +4475,141 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
             ],
-            "name": "Pleroma"
+            "name": null
         },
         {
             "constellation": {
@@ -4634,141 +4634,141 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
             ],
-            "name": "Plume"
+            "name": null
         },
         {
             "constellation": {
@@ -4793,141 +4793,141 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
             ],
-            "name": "Postmarks"
+            "name": null
         },
         {
             "constellation": {
@@ -4952,141 +4952,141 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
             ],
-            "name": "Snac"
+            "name": null
         },
         {
             "constellation": {
@@ -5111,141 +5111,141 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
             ],
-            "name": "Streams"
+            "name": null
         },
         {
             "constellation": {
@@ -5270,141 +5270,141 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
             ],
-            "name": "Sutty"
+            "name": null
         },
         {
             "constellation": {
@@ -5429,141 +5429,141 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
             ],
-            "name": "Takahē"
+            "name": null
         },
         {
             "constellation": {
@@ -5588,141 +5588,141 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
             ],
-            "name": "Threads"
+            "name": null
         },
         {
             "constellation": {
@@ -5736,7 +5736,7 @@
                         "parameters": {
                             "app": "Wildebeest",
                             "hostname": "cloudflare.social",
-                            "existing-account-uri": "acct:gargron@cloudflare.social",
+                            "existing-account-uri": "acct:cloudflare@cloudflare.social",
                             "nonexisting-account-uri": "acct:does-not-exist@cloudflare.social"
                         }
                     }
@@ -5747,141 +5747,141 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
             ],
-            "name": "Wildebeest"
+            "name": null
         },
         {
             "constellation": {
@@ -5906,141 +5906,141 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
             ],
-            "name": "WordPress + ActivityPub plugin"
+            "name": null
         },
         {
             "constellation": {
@@ -6065,141 +6065,141 @@
                 {
                     "name": "webfinger.server.4_1__2_parameter_ordering_not_significant::parameter_ordering",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__14_must_only_redirect_to_https::must_only_redirect_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__2_perform_query::normal_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__3_requires_resource_uri::requires_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::double_equals_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_http_status",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__4_do_not_accept_malformed_resource_parameters::requires_valid_resource_uri_jrd",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__5_status_404_for_nonexisting_resources::status_404_for_nonexisting_resources",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_2__9_content_type::returns_jrd_in_response_to_https",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4_5__1_any_uri_scheme_for_resource_identifiers::any_uri_scheme_for_resource_identifiers",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_combined_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_known_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__1_accepts_all_link_rels_in_query::accepts_unknown_link_rels_in_query",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.4__3_only_returns_jrd_in_response_to_https_requests::does_not_return_jrd_in_response_to_http",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 },
                 {
                     "name": "webfinger.server.5_1_cors_header_required::cors_header_required",
                     "rolemapping": {
-                        "server": "server",
-                        "client": "client"
+                        "client": "client",
+                        "server": "server"
                     },
                     "skip": null
                 }
             ],
-            "name": "WriteFreely"
+            "name": null
         }
     ],
     "name": "Webfinger server tests of hosted Fediverse applications"


### PR DESCRIPTION
The previous activitypubrelay node was "network unreachable".

The cloudflare generated constellation change was from a previous PR that changed the node?
