### PR TITLE
Change Friendica host to forum.friendi.ca

### DIFF
--- a/production/constellations/imp-vs-friendica-acct_tobias@friendi.ca.json
+++ b/production/constellations/imp-vs-friendica-acct_tobias@friendi.ca.json
@@ -8,9 +8,9 @@
             "nodedriver": "saas.SaasFediverseNodeDriver",
             "parameters": {
                 "app": "Friendica",
-                "hostname": "friendi.ca",
-                "existing-account-uri": "acct:tobias@friendi.ca",
-                "nonexisting-account-uri": "acct:does-not-exist@friendi.ca"
+                "hostname": "forum.friendi.ca",
+                "existing-account-uri": "acct:helpers@forum.friendi.ca",
+                "nonexisting-account-uri": "acct:does-not-exist@forum.friendi.ca"
             }
         }
     },

--- a/production/nodes/friendica-acct_tobias@friendi.ca.json
+++ b/production/nodes/friendica-acct_tobias@friendi.ca.json
@@ -2,8 +2,8 @@
     "nodedriver": "saas.SaasFediverseNodeDriver",
     "parameters": {
         "app" : "Friendica",
-        "hostname": "friendi.ca",
-        "existing-account-uri": "acct:tobias@friendi.ca",
-        "nonexisting-account-uri": "acct:does-not-exist@friendi.ca"
+        "hostname": "forum.friendi.ca",
+        "existing-account-uri": "acct:helpers@forum.friendi.ca",
+        "nonexisting-account-uri": "acct:does-not-exist@forum.friendi.ca"
     }
 }

--- a/production/testplans/webfinger-server-all-wellknown-saas-imp.json
+++ b/production/testplans/webfinger-server-all-wellknown-saas-imp.json
@@ -4940,9 +4940,9 @@
                         "nodedriver": "saas.SaasFediverseNodeDriver",
                         "parameters": {
                             "app": "Friendica",
-                            "hostname": "friendi.ca",
-                            "existing-account-uri": "acct:tobias@friendi.ca",
-                            "nonexisting-account-uri": "acct:does-not-exist@friendi.ca"
+                            "hostname": "forum.friendi.ca",
+                            "existing-account-uri": "acct:helpers@forum.friendi.ca",
+                            "nonexisting-account-uri": "acct:does-not-exist@forum.friendi.ca"
                         }
                     }
                 },


### PR DESCRIPTION
The friendi.ca instance is actually Wordpress, so this is testing the wrong thing.  The forums on forum.friendi.ca are actually Friendica, and also host all the public support channels for Friendica, so this is a better official account to use than just Tobias.