### PR TITLE
Follow test updates. Requires Mastodon API node

### DIFF
--- a/example-testplans/mastodon-follow-local.json
+++ b/example-testplans/mastodon-follow-local.json
@@ -1,0 +1,39 @@
+{
+    "name": "mastodon-follow-local",
+    "sessions": [
+        {
+            "name": "mastodon api",
+            "constellation": {
+                "name": "single server",
+                "roles": {
+                    "leader_node": {
+                        "nodedriver": "mastodon.api.MastodonNodeDriver",
+                        "parameters": {
+                            "hostname": "HOSTNAME_PLACEHOLDER",
+                            "access_token": "ACCESS_TOKEN_PLACEHOLDER"
+                        }
+                    },
+                    "follower_node": {
+                        "nodedriver": "mastodon.api.MastodonNodeDriver",
+                        "parameters": {
+                            "hostname": "HOSTNAME_PLACEHOLDER",
+                            "actors": {
+                                "default_role": "default",
+                                "roles": {
+                                    "default": {
+                                        "access_token": "ACCESS_TOKEN_PLACEHOLDER"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "tests": [
+                {
+                    "name": "fediverse.follow.leader_accepts_follow_request::AcceptFollowTest"
+                }
+            ]
+        }
+    ]
+}

--- a/tests/fediverse/follow/__init__.py
+++ b/tests/fediverse/follow/__init__.py
@@ -38,7 +38,7 @@ class AbstractFollowTest:
 
     def test_following(self):
         # FIXME: decide on SpecLevel, InteropLevel for these assertions
-        self.to_be_leader_node.assert_member_of_collection_at(self.follower_actor_uri, self.leader_actor_followers_collection_uri)
-        self.to_be_leader_node.assert_not_member_of_collection_at(self.follower_actor_uri, self.leader_actor_following_collection_uri)
-        self.to_be_follower_node.assert_not_member_of_collection_at(self.leader_actor_uri, self.follower_actor_followers_collection_uri)
-        self.to_be_follower_node.assert_member_of_collection_at(self.leader_actor_uri, self.follower_actor_following_collection_uri)
+        self.leader_node.assert_member_of_collection_at(self.follower_actor_uri, self.leader_actor_followers_collection_uri)
+        self.leader_node.assert_not_member_of_collection_at(self.follower_actor_uri, self.leader_actor_following_collection_uri)
+        self.follower_node.assert_not_member_of_collection_at(self.leader_actor_uri, self.follower_actor_followers_collection_uri)
+        self.follower_node.assert_member_of_collection_at(self.leader_actor_uri, self.follower_actor_following_collection_uri)

--- a/tests/fediverse/follow/leader_accepts_follow_request.py
+++ b/tests/fediverse/follow/leader_accepts_follow_request.py
@@ -5,6 +5,7 @@ From https://github.com/fediverse-devnet/feditest-tests-fediverse/issues/24
 """
 
 from feditest import step, test
+
 from . import AbstractFollowTest
 
 
@@ -21,18 +22,18 @@ class AcceptFollowTest(AbstractFollowTest):
 
     @step
     def get_collections(self):
-        super().get_collections();
+        super().get_collections()
 
 
     @step
     def initially_unrelated(self):
         # Initially they are unrelated
-        super().test_unrelated();
+        super().test_unrelated()
 
 
     @step
     def setup_follow(self):
-        self.follower_node_node.make_a_follow_b(self.follower_actor_uri, self.leader_actor_uri, self.leader_node)
+        self.follower_node.make_a_follow_b(self.follower_actor_uri, self.leader_actor_uri, self.leader_node)
 
 
     @step


### PR DESCRIPTION
It also requires the example test plan to be customized for the deployment context. I used a manually deployed Mastodon instance with two actors, where one follows the other.

NOTE: The `feditest` Mastodon API node code should be merged before this PR.