### PR TITLE
Update tests to support servers that non-https endpoints.

### DIFF
--- a/tests/webfinger/client/4_2__10_must_accept_non_existing_empty_elements.py
+++ b/tests/webfinger/client/4_2__10_must_accept_non_existing_empty_elements.py
@@ -1,9 +1,10 @@
 import json
-from hamcrest import calling, is_not, raises
 
 from feditest import InteropLevel, SpecLevel, assert_that, test
 from feditest.protocols.webfinger import WebFingerClient, WebFingerServer
 from feditest.protocols.webfinger.traffic import WebFingerQueryResponse
+from hamcrest import calling, is_not, raises
+
 
 def test_one(
         client: WebFingerClient,
@@ -16,7 +17,7 @@ def test_one(
 
     webfinger_response : WebFingerQueryResponse = server.override_webfinger_response(
             lambda:
-                client.perform_webfinger_query(test_id),
+                client.perform_webfinger_query(server, test_id),
             {
                 test_id : overridden_jrd_json_string
             }

--- a/tests/webfinger/client/4_2__12_follow_redirects.py
+++ b/tests/webfinger/client/4_2__12_follow_redirects.py
@@ -1,10 +1,10 @@
-from hamcrest import equal_to
-from multidict import MultiDict
-
 from feditest import InteropLevel, SpecLevel, assert_that, test
 from feditest.protocols.web.traffic import HttpResponse
 from feditest.protocols.webfinger import WebFingerClient, WebFingerServer
 from feditest.protocols.webfinger.traffic import WebFingerQueryResponse
+from hamcrest import equal_to
+from multidict import MultiDict
+
 
 @test
 def follow_redirects(
@@ -16,7 +16,7 @@ def follow_redirects(
     webfinger_uri = client.construct_webfinger_uri_for(test_id)
     hostname = server.hostname
 
-    normal_response = client.perform_webfinger_query(test_id)
+    normal_response = client.perform_webfinger_query(server, test_id)
 
     # can have any arguments per section 7
     redirect_https_uri = f'https://{ hostname }/foo?abc=def&ghi=jkl'
@@ -25,7 +25,7 @@ def follow_redirects(
     jrd_headers = MultiDict([('content-type', 'application/jrd+json')])
 
     overridden_redirect_to_https_response : WebFingerQueryResponse = server.override_http_response(
-            lambda: client.perform_webfinger_query(test_id),
+            lambda: client.perform_webfinger_query(server, test_id),
             {
                 webfinger_uri : HttpResponse(301,  MultiDict([('location', redirect_https_uri)]).extend(jrd_headers), None ),
                 redirect_https_uri : HttpResponse( 200, jrd_headers, normal_response.http_request_response_pair.response.payload)
@@ -34,7 +34,7 @@ def follow_redirects(
     assert_that(overridden_redirect_to_https_response, equal_to(normal_response), spec_level=SpecLevel.MUST, interop_level=InteropLevel.PROBLEM)
 
     overridden_redirect_to_http_response : WebFingerQueryResponse = server.override_http_response(
-            lambda: client.perform_webfinger_query(test_id),
+            lambda: client.perform_webfinger_query(server, test_id),
             {
                 webfinger_uri : HttpResponse(301, MultiDict([('location', redirect_http_uri)]).extend(jrd_headers), None ),
                 redirect_http_uri : HttpResponse( 200, jrd_headers, normal_response.http_request_response_pair.response.payload)

--- a/tests/webfinger/client/4_3__6_accept_example_response.py
+++ b/tests/webfinger/client/4_3__6_accept_example_response.py
@@ -4,6 +4,7 @@ from feditest import InteropLevel, SpecLevel, assert_that, test
 from feditest.protocols.webfinger import WebFingerClient, WebFingerServer
 from feditest.protocols.webfinger.traffic import WebFingerQueryResponse
 
+
 @test
 def accept_example_response(
         client: WebFingerClient,
@@ -37,7 +38,7 @@ def accept_example_response(
 
     webfinger_response : WebFingerQueryResponse = server.override_webfinger_response(
             lambda:
-                client.perform_webfinger_query(test_id),
+                client.perform_webfinger_query(server, test_id),
             {
                 test_id : overridden_jrd_json_string
             }

--- a/tests/webfinger/client/4_4_1__2_accept_jrds_with_subject.py
+++ b/tests/webfinger/client/4_4_1__2_accept_jrds_with_subject.py
@@ -5,6 +5,7 @@ from feditest.protocols.web.traffic import ParsedUri
 from feditest.protocols.webfinger import WebFingerClient, WebFingerServer
 from feditest.protocols.webfinger.traffic import WebFingerQueryResponse
 
+
 @test
 def accept_jrds_with_subject(
         client: WebFingerClient,
@@ -21,7 +22,7 @@ def accept_jrds_with_subject(
 
         with_subject_response = server.override_webfinger_response(
             lambda:
-                client.perform_webfinger_query(test_id),
+                client.perform_webfinger_query(server, test_id),
             {
                 test_id : json.dumps(json_with_subject)
             }

--- a/tests/webfinger/client/4_4_1__3_accept_jrds_without_subject.py
+++ b/tests/webfinger/client/4_4_1__3_accept_jrds_without_subject.py
@@ -4,6 +4,7 @@ from feditest import InteropLevel, SpecLevel, assert_that, test
 from feditest.protocols.webfinger import WebFingerClient, WebFingerServer
 from feditest.protocols.webfinger.traffic import WebFingerQueryResponse
 
+
 @test
 def accept_jrds_without_subject(
         client: WebFingerClient,
@@ -19,7 +20,7 @@ def accept_jrds_without_subject(
         json_without_subject.pop('subject')
 
         without_subject_response : WebFingerQueryResponse = server.override_webfinger_response(
-            lambda: client.perform_webfinger_query(test_id),
+            lambda: client.perform_webfinger_query(server, test_id),
             {
                 test_id : json.dumps(json_without_subject)
             }

--- a/tests/webfinger/client/4_4__1_rejects_invalid_json.py
+++ b/tests/webfinger/client/4_4__1_rejects_invalid_json.py
@@ -2,6 +2,7 @@ from feditest import InteropLevel, SpecLevel, assert_that, test
 from feditest.protocols.webfinger import WebFingerClient, WebFingerServer
 from feditest.protocols.webfinger.traffic import WebFingerQueryResponse
 
+
 @test
 def rejects_invalid_json(
         client: WebFingerClient,
@@ -36,7 +37,7 @@ def rejects_invalid_json(
 
     webfinger_response : WebFingerQueryResponse = server.override_webfinger_response(
             lambda:
-                client.perform_webfinger_query(test_id),
+                client.perform_webfinger_query(server, test_id),
             {
                 test_id : overridden_jrd_json_string
             }

--- a/tests/webfinger/client/4_4__2_accept_unknown_entries.py
+++ b/tests/webfinger/client/4_4__2_accept_unknown_entries.py
@@ -4,6 +4,7 @@ from feditest import InteropLevel, SpecLevel, assert_that, test
 from feditest.protocols.webfinger import WebFingerClient, WebFingerServer
 from feditest.protocols.webfinger.traffic import WebFingerQueryResponse
 
+
 @test
 def accept_unknown_entries(
         client: WebFingerClient,
@@ -44,7 +45,7 @@ def accept_unknown_entries(
 
     webfinger_response : WebFingerQueryResponse = server.override_webfinger_response(
             lambda:
-                client.perform_webfinger_query(test_id),
+                client.perform_webfinger_query(server, test_id),
             {
                 test_id : overridden_jrd_json_string
             }

--- a/tests/webfinger/client/4__2_only_https_requests.py
+++ b/tests/webfinger/client/4__2_only_https_requests.py
@@ -1,9 +1,9 @@
-from hamcrest import equal_to, is_not, all_of
-
 from feditest import InteropLevel, SpecLevel, assert_that, test
-from feditest.utils import uri_parse_validate
 from feditest.protocols.web.traffic import HttpResponse, ParsedUri
 from feditest.protocols.webfinger import WebFingerClient, WebFingerServer
+from feditest.utils import uri_parse_validate
+from hamcrest import all_of, equal_to, is_not
+
 
 @test
 def only_https_requests(
@@ -13,7 +13,7 @@ def only_https_requests(
     test_ids =[ server.obtain_account_identifier() ]
 
     responses : list[HttpResponse] = server.transaction(
-            lambda:[ client.perform_webfinger_query(test_id) for test_id in test_ids ]
+            lambda:[ client.perform_webfinger_query(server, test_id) for test_id in test_ids ]
     ).entries()
 
     assert(len(responses) == len(test_ids))

--- a/tests/webfinger/server/4_1__2_parameter_ordering_not_significant.py
+++ b/tests/webfinger/server/4_1__2_parameter_ordering_not_significant.py
@@ -1,11 +1,10 @@
-from hamcrest import none
-
 from feditest import InteropLevel, SpecLevel, assert_that, test
 from feditest.protocols import SkipTestException
 from feditest.protocols.web import WebClient
 from feditest.protocols.webfinger import WebFingerClient, WebFingerServer
 from feditest.protocols.webfinger.traffic import ClaimedJrd
 from feditest.protocols.webfinger.utils import none_except, recursive_equal_to, wf_error
+from hamcrest import none
 
 RELS = [
     'http://webfinger.net/rel/profile-page',
@@ -26,7 +25,7 @@ def parameter_ordering(
     first_webfinger_response = None
     for i in range(0, len(RELS)):
         rels = RELS[i:] + RELS[0:i]
-        webfinger_response = client.perform_webfinger_query(test_id, rels)
+        webfinger_response = client.perform_webfinger_query(server, test_id, rels)
 
         assert_that(
                 webfinger_response.exc,

--- a/tests/webfinger/server/4_2__14_must_only_redirect_to_https.py
+++ b/tests/webfinger/server/4_2__14_must_only_redirect_to_https.py
@@ -1,8 +1,7 @@
-from hamcrest import equal_to
-
 from feditest import InteropLevel, SpecLevel, assert_that, test
 from feditest.protocols.webfinger import WebFingerClient, WebFingerServer
 from feditest.protocols.webfinger.traffic import WebFingerQueryResponse
+from hamcrest import equal_to
 
 
 @test
@@ -15,7 +14,7 @@ def must_only_redirect_to_https(
     """
     test_id = server.obtain_account_identifier()
 
-    response : WebFingerQueryResponse = client.perform_webfinger_query(test_id)
+    response : WebFingerQueryResponse = client.perform_webfinger_query(server, test_id)
     assert_that(
             response.http_request_response_pair.final_request.uri.scheme,
             equal_to('https'),

--- a/tests/webfinger/server/4_2__2_perform_query.py
+++ b/tests/webfinger/server/4_2__2_perform_query.py
@@ -1,8 +1,8 @@
-from hamcrest import none, not_none
-
 from feditest import InteropLevel, SpecLevel, assert_that, test
 from feditest.protocols.webfinger import WebFingerClient, WebFingerServer
 from feditest.protocols.webfinger.utils import wf_error
+from hamcrest import none, not_none
+
 
 @test
 def normal_query(
@@ -14,7 +14,7 @@ def normal_query(
     """
     test_id = server.obtain_account_identifier()
 
-    webfinger_response = client.perform_webfinger_query(test_id)
+    webfinger_response = client.perform_webfinger_query(server, test_id)
 
     assert_that(
             webfinger_response.exc,

--- a/tests/webfinger/server/4__1_accepts_all_link_rels_in_query.py
+++ b/tests/webfinger/server/4__1_accepts_all_link_rels_in_query.py
@@ -1,12 +1,15 @@
-from hamcrest import none
-
 from feditest import InteropLevel, SpecLevel, assert_that, test
 from feditest.protocols import SkipTestException
 from feditest.protocols.web import WebClient
 from feditest.protocols.webfinger import WebFingerClient, WebFingerServer
 from feditest.protocols.webfinger.traffic import ClaimedJrd, WebFingerQueryResponse
-from feditest.protocols.webfinger.utils import link_subset_or_equal_to, none_except, wf_error
+from feditest.protocols.webfinger.utils import (
+    link_subset_or_equal_to,
+    none_except,
+    wf_error,
+)
 from feditest.reporting import info
+from hamcrest import none
 
 # Note: we do not try all the known rel values, only the ones known to be used in a webfinger context
 # See also https://fedidevs.org/reference/webfinger/
@@ -58,7 +61,7 @@ def accepts_known_link_rels_in_query(
     Tests one known link rel at a time.
     """
     test_id = server.obtain_account_identifier()
-    response_without_rel : WebFingerQueryResponse = client.perform_webfinger_query(test_id)
+    response_without_rel = client.perform_webfinger_query(server, test_id)
     if ( response_without_rel.exc
          and response_without_rel.exc in (WebClient.WrongContentTypeError, ClaimedJrd.InvalidMediaTypeError, ClaimedJrd.InvalidRelError)
     ):
@@ -100,7 +103,7 @@ def accepts_unknown_link_rels_in_query(
     """
     test_id = server.obtain_account_identifier()
 
-    response_without_rel = client.perform_webfinger_query(test_id)
+    response_without_rel = client.perform_webfinger_query(server, test_id)
     if ( response_without_rel.exc
          and response_without_rel.exc in (WebClient.WrongContentTypeError, ClaimedJrd.InvalidMediaTypeError, ClaimedJrd.InvalidRelError)
     ):
@@ -141,7 +144,7 @@ def accepts_combined_link_rels_in_query(
     """
     test_id = server.obtain_account_identifier()
 
-    response_without_rel = client.perform_webfinger_query(test_id)
+    response_without_rel = client.perform_webfinger_query(server, test_id)
     if ( response_without_rel.exc
          and response_without_rel.exc in (WebClient.WrongContentTypeError, ClaimedJrd.InvalidMediaTypeError, ClaimedJrd.InvalidRelError)
     ):

--- a/tests/webfinger/server/5_1_cors_header_required.py
+++ b/tests/webfinger/server/5_1_cors_header_required.py
@@ -14,7 +14,7 @@ def cors_header_required(
     """
     test_id = server.obtain_account_identifier()
 
-    pair : HttpRequestResponsePair = client.perform_webfinger_query(test_id).http_request_response_pair
+    pair = client.perform_webfinger_query(server, test_id).http_request_response_pair
 
     assert_that(
             'access-control-allow-origin' in pair.response.response_headers,


### PR DESCRIPTION
Added the `server` argument to `perform_webfinger_query`.