### PR TITLE
Track https://github.com/fediverse-devnet/feditest/pull/324

### DIFF
--- a/tests/webfinger/client/4_2__10_must_accept_non_existing_empty_elements.py
+++ b/tests/webfinger/client/4_2__10_must_accept_non_existing_empty_elements.py
@@ -17,7 +17,7 @@ def test_one(
 
     webfinger_response : WebFingerQueryResponse = server.override_webfinger_response(
             lambda:
-                client.perform_webfinger_query(server, test_id),
+                client.perform_webfinger_query(test_id),
             {
                 test_id : overridden_jrd_json_string
             }

--- a/tests/webfinger/client/4_2__12_follow_redirects.py
+++ b/tests/webfinger/client/4_2__12_follow_redirects.py
@@ -16,7 +16,7 @@ def follow_redirects(
     webfinger_uri = client.construct_webfinger_uri_for(test_id)
     hostname = server.hostname
 
-    normal_response = client.perform_webfinger_query(server, test_id)
+    normal_response = client.perform_webfinger_query(test_id)
 
     # can have any arguments per section 7
     redirect_https_uri = f'https://{ hostname }/foo?abc=def&ghi=jkl'
@@ -25,7 +25,7 @@ def follow_redirects(
     jrd_headers = MultiDict([('content-type', 'application/jrd+json')])
 
     overridden_redirect_to_https_response : WebFingerQueryResponse = server.override_http_response(
-            lambda: client.perform_webfinger_query(server, test_id),
+            lambda: client.perform_webfinger_query(test_id),
             {
                 webfinger_uri : HttpResponse(301,  MultiDict([('location', redirect_https_uri)]).extend(jrd_headers), None ),
                 redirect_https_uri : HttpResponse( 200, jrd_headers, normal_response.http_request_response_pair.response.payload)
@@ -34,7 +34,7 @@ def follow_redirects(
     assert_that(overridden_redirect_to_https_response, equal_to(normal_response), spec_level=SpecLevel.MUST, interop_level=InteropLevel.PROBLEM)
 
     overridden_redirect_to_http_response : WebFingerQueryResponse = server.override_http_response(
-            lambda: client.perform_webfinger_query(server, test_id),
+            lambda: client.perform_webfinger_query(test_id),
             {
                 webfinger_uri : HttpResponse(301, MultiDict([('location', redirect_http_uri)]).extend(jrd_headers), None ),
                 redirect_http_uri : HttpResponse( 200, jrd_headers, normal_response.http_request_response_pair.response.payload)

--- a/tests/webfinger/client/4_3__6_accept_example_response.py
+++ b/tests/webfinger/client/4_3__6_accept_example_response.py
@@ -38,7 +38,7 @@ def accept_example_response(
 
     webfinger_response : WebFingerQueryResponse = server.override_webfinger_response(
             lambda:
-                client.perform_webfinger_query(server, test_id),
+                client.perform_webfinger_query(test_id),
             {
                 test_id : overridden_jrd_json_string
             }

--- a/tests/webfinger/client/4_4_1__2_accept_jrds_with_subject.py
+++ b/tests/webfinger/client/4_4_1__2_accept_jrds_with_subject.py
@@ -22,7 +22,7 @@ def accept_jrds_with_subject(
 
         with_subject_response = server.override_webfinger_response(
             lambda:
-                client.perform_webfinger_query(server, test_id),
+                client.perform_webfinger_query(test_id),
             {
                 test_id : json.dumps(json_with_subject)
             }

--- a/tests/webfinger/client/4_4_1__3_accept_jrds_without_subject.py
+++ b/tests/webfinger/client/4_4_1__3_accept_jrds_without_subject.py
@@ -20,7 +20,7 @@ def accept_jrds_without_subject(
         json_without_subject.pop('subject')
 
         without_subject_response : WebFingerQueryResponse = server.override_webfinger_response(
-            lambda: client.perform_webfinger_query(server, test_id),
+            lambda: client.perform_webfinger_query(test_id),
             {
                 test_id : json.dumps(json_without_subject)
             }

--- a/tests/webfinger/client/4_4__1_rejects_invalid_json.py
+++ b/tests/webfinger/client/4_4__1_rejects_invalid_json.py
@@ -37,7 +37,7 @@ def rejects_invalid_json(
 
     webfinger_response : WebFingerQueryResponse = server.override_webfinger_response(
             lambda:
-                client.perform_webfinger_query(server, test_id),
+                client.perform_webfinger_query(test_id),
             {
                 test_id : overridden_jrd_json_string
             }

--- a/tests/webfinger/client/4_4__2_accept_unknown_entries.py
+++ b/tests/webfinger/client/4_4__2_accept_unknown_entries.py
@@ -45,7 +45,7 @@ def accept_unknown_entries(
 
     webfinger_response : WebFingerQueryResponse = server.override_webfinger_response(
             lambda:
-                client.perform_webfinger_query(server, test_id),
+                client.perform_webfinger_query(test_id),
             {
                 test_id : overridden_jrd_json_string
             }

--- a/tests/webfinger/client/4__2_only_https_requests.py
+++ b/tests/webfinger/client/4__2_only_https_requests.py
@@ -10,10 +10,10 @@ def only_https_requests(
         client: WebFingerClient,
         server: WebFingerServer
 ) -> None:
-    test_ids =[ server.obtain_account_identifier() ]
+    test_ids = [ server.obtain_account_identifier() ]
 
     responses : list[HttpResponse] = server.transaction(
-            lambda:[ client.perform_webfinger_query(server, test_id) for test_id in test_ids ]
+            lambda:[ client.perform_webfinger_query(test_id) for test_id in test_ids ]
     ).entries()
 
     assert(len(responses) == len(test_ids))

--- a/tests/webfinger/server/4_1__2_parameter_ordering_not_significant.py
+++ b/tests/webfinger/server/4_1__2_parameter_ordering_not_significant.py
@@ -25,7 +25,7 @@ def parameter_ordering(
     first_webfinger_response = None
     for i in range(0, len(RELS)):
         rels = RELS[i:] + RELS[0:i]
-        webfinger_response = client.perform_webfinger_query(server, test_id, rels)
+        webfinger_response = client.perform_webfinger_query(test_id, rels=rels)
 
         assert_that(
                 webfinger_response.exc,

--- a/tests/webfinger/server/4_2__14_must_only_redirect_to_https.py
+++ b/tests/webfinger/server/4_2__14_must_only_redirect_to_https.py
@@ -14,7 +14,7 @@ def must_only_redirect_to_https(
     """
     test_id = server.obtain_account_identifier()
 
-    response : WebFingerQueryResponse = client.perform_webfinger_query(server, test_id)
+    response : WebFingerQueryResponse = client.perform_webfinger_query(test_id)
     assert_that(
             response.http_request_response_pair.final_request.uri.scheme,
             equal_to('https'),

--- a/tests/webfinger/server/4_2__2_perform_query.py
+++ b/tests/webfinger/server/4_2__2_perform_query.py
@@ -14,7 +14,7 @@ def normal_query(
     """
     test_id = server.obtain_account_identifier()
 
-    webfinger_response = client.perform_webfinger_query(server, test_id)
+    webfinger_response = client.perform_webfinger_query(test_id)
 
     assert_that(
             webfinger_response.exc,

--- a/tests/webfinger/server/4__1_accepts_all_link_rels_in_query.py
+++ b/tests/webfinger/server/4__1_accepts_all_link_rels_in_query.py
@@ -61,7 +61,7 @@ def accepts_known_link_rels_in_query(
     Tests one known link rel at a time.
     """
     test_id = server.obtain_account_identifier()
-    response_without_rel = client.perform_webfinger_query(server, test_id)
+    response_without_rel = client.perform_webfinger_query(test_id)
     if ( response_without_rel.exc
          and response_without_rel.exc in (WebClient.WrongContentTypeError, ClaimedJrd.InvalidMediaTypeError, ClaimedJrd.InvalidRelError)
     ):
@@ -76,7 +76,7 @@ def accepts_known_link_rels_in_query(
 
     for rel in KNOWN_RELS:
         info(f'WebFinger query for resource "{test_id}" with rel "{rel}"')
-        response_with_rel : WebFingerQueryResponse = client.perform_webfinger_query(test_id, [rel])
+        response_with_rel : WebFingerQueryResponse = client.perform_webfinger_query(test_id, rels=[rel])
         assert_that(
                 response_without_rel.exc,
                 none(),
@@ -103,7 +103,7 @@ def accepts_unknown_link_rels_in_query(
     """
     test_id = server.obtain_account_identifier()
 
-    response_without_rel = client.perform_webfinger_query(server, test_id)
+    response_without_rel = client.perform_webfinger_query(test_id)
     if ( response_without_rel.exc
          and response_without_rel.exc in (WebClient.WrongContentTypeError, ClaimedJrd.InvalidMediaTypeError, ClaimedJrd.InvalidRelError)
     ):
@@ -117,7 +117,7 @@ def accepts_unknown_link_rels_in_query(
             interop_level=InteropLevel.PROBLEM)
 
     for rel in UNKNOWN_RELS:
-        response_with_rel = client.perform_webfinger_query(test_id, [rel])
+        response_with_rel = client.perform_webfinger_query(test_id, rels=[rel])
         assert_that(
                 response_without_rel.exc,
                 none(),
@@ -144,7 +144,7 @@ def accepts_combined_link_rels_in_query(
     """
     test_id = server.obtain_account_identifier()
 
-    response_without_rel = client.perform_webfinger_query(server, test_id)
+    response_without_rel = client.perform_webfinger_query(test_id)
     if ( response_without_rel.exc
          and response_without_rel.exc in (WebClient.WrongContentTypeError, ClaimedJrd.InvalidMediaTypeError, ClaimedJrd.InvalidRelError)
     ):
@@ -161,7 +161,7 @@ def accepts_combined_link_rels_in_query(
     for rel1 in KNOWN_RELS:
         for rel2 in UNKNOWN_RELS:
             rels = [rel1, rel2] if count % 2 else [rel2, rel1]
-            response_with_rel = client.perform_webfinger_query(test_id, rels)
+            response_with_rel = client.perform_webfinger_query(test_id, rels=rels)
             assert_that(
                     response_without_rel.exc,
                     none(),

--- a/tests/webfinger/server/5_1_cors_header_required.py
+++ b/tests/webfinger/server/5_1_cors_header_required.py
@@ -14,7 +14,7 @@ def cors_header_required(
     """
     test_id = server.obtain_account_identifier()
 
-    pair = client.perform_webfinger_query(server, test_id).http_request_response_pair
+    pair = client.perform_webfinger_query(test_id).http_request_response_pair
 
     assert_that(
             'access-control-allow-origin' in pair.response.response_headers,


### PR DESCRIPTION
API now does not (and should never have had) server parameter for WebFingerClientNode's webfinger invocations